### PR TITLE
Allow custom namespace and key separators (remove hard coding).

### DIFF
--- a/client/app/modules/translate/resourceEditor.js
+++ b/client/app/modules/translate/resourceEditor.js
@@ -323,8 +323,13 @@ function(Backbone, ns, resSync, i18n) {
 
             var self = this;
 
-            var opts = {};
+            // test using the provided i18next options as a base
+            var opts = resSync.options || {};
+
+            // The default namespace to test is the current namespace
+            opts.ns = self.model.get('ns');
             
+            // replace default options with any provided in test window
             var args = self.$('.i18nOptions').val();
             if (args.length > 0) {
                 args = args.replace(new RegExp(' = ', 'g'), '=').split(/\n|\r/);
@@ -340,7 +345,7 @@ function(Backbone, ns, resSync, i18n) {
             }
 
             function test(t, o) {
-                self.$('.translated').html(t(self.model.get('ns') + ':' + self.model.id, o));
+                self.$('.translated').html(t(self.model.id, o));
             }
 
             if (!resSync.i18nDirty) {
@@ -373,10 +378,12 @@ function(Backbone, ns, resSync, i18n) {
         prepareI18n: function(cb) {
             var self= this;
 
-            i18n.init({
+            var options = _.extend(resSync.options, {
                 resStore: resSync.resStore,
                 lng: this.model.get('lng')
-            }, function(t) {
+            });
+
+            i18n.init(options, function(t) {
                 resSync.i18nDirty = true;
                 cb(t);
             });

--- a/client/app/modules/translate/resourceSync.js
+++ b/client/app/modules/translate/resourceSync.js
@@ -113,14 +113,16 @@ function(Backbone, ns, _, $, i18n) {
                       , key = parentKey;
 
                     if (key.length > 0) {
-                        key = key + ' .' + m;
+                        // Key later becomes Model.id and therefore affects how keys are saved
+                        // So use keyseparator here
+                        key = key + ' ' + defaults.keyseparator + m;
                     } else {
                         key = m;
                     }
 
                     if (typeof value === 'string') {
                         kv = { 
-                            id: key.replace(new RegExp(' ', 'g'), ''),
+                            id: key.replace(new RegExp('\\b ', 'g'), ''),
                             lng: lng,
                             ns: ns,
                             key: key,
@@ -133,7 +135,7 @@ function(Backbone, ns, _, $, i18n) {
                         appendTo.push(kv);
                     } else if (Object.prototype.toString.apply(value) === '[object Array]') {
                         kv = { 
-                            id: key.replace(new RegExp(' ', 'g'), ''),
+                            id: key.replace(new RegExp('\\b ', 'g'), ''),
                             lng: lng,
                             ns: ns,
                             key: key,
@@ -221,7 +223,7 @@ function(Backbone, ns, _, $, i18n) {
                     i18n.functions.log('posted change key \'' + key + '\' to: ' + url);
 
                     // update resStore
-                    var keys = key.split('.');
+                    var keys = key.split(self.options.keyseparator);
                     var x = 0;
                     var val = self.resStore[lng][ns];
                     while (keys[x]) {
@@ -262,7 +264,8 @@ function(Backbone, ns, _, $, i18n) {
 
                         flat = self.flat[lng][ns].get(key);
                         if (!flat) {
-                            var k = key.split('.').join(' .');
+                            var k = key.split(self.options.keyseparator)
+                                       .join(' ' + self.options.keyseparator);
                             self.flat[lng][ns].push({
                                 id: key,
                                 key: k,
@@ -308,7 +311,7 @@ function(Backbone, ns, _, $, i18n) {
                     i18n.functions.log('posted remove key \'' + key + '\' to: ' + url);
 
                     // update resStore
-                    var keys = key.split('.');
+                    var keys = key.split(self.options.keyseparator);
                     var x = 0;
                     var val = self.resStore[lng][ns];
                     while (keys[x]) {

--- a/client/app/namespace.js
+++ b/client/app/namespace.js
@@ -29,7 +29,7 @@ function($, _, backstrapp, Backbone, Handlebars, i18next) {
 
     Handlebars.registerHelper('parseKey', function(key) {
        if (!key) return '';
-       var result = key.replace(new RegExp(' ', 'g'), '<br />&nbsp;&nbsp;');
+       var result = key.replace(new RegExp('\\b ', 'g'), '<br />&nbsp;&nbsp;');
 
        return new Handlebars.SafeString(result);
     });

--- a/package.json
+++ b/package.json
@@ -1,28 +1,27 @@
 {
-  "author": "jamuhl"
-  , "name": "i18next-webtranslate"
-  , "version": "0.0.0"
-  , "private": true
-  , "main": "server.js"
-  , "engines": {
-        "node": ">= 0.6.18"
-      , "npm": ">= 1.1.x"
-    }
-  , "dependencies": {
-      "grunt": "*"
-    , "grunt-contrib": ">=0.1.0"
-    , "requirejs": "2.0.6"
-    , "express": ">= 3.0.x"
-    , "stylus": ">= 0.24.0"
-    , "nib": ">= 0.3.2"
-    , "jade": ">= 0.0.1"
-    , "markdown": ">= 0.4.0"
-    , "handlebars": ">= 0.0.1"
-    , "async": ">= 0.1.18"
-    , "lodash": ">= 0.5.x"
-    , "zipstream": ">=0.2.1"
-    , "i18next": ">=1.5.0"
-    }
-  , "devDependencies": {}
-  , "scripts": {}
+  "author": "jamuhl",
+  "name": "i18next-webtranslate",
+  "version": "0.0.0",
+  "private": true,
+  "main": "server.js",
+  "engines": {
+    "node": ">= 0.6.18",
+    "npm": ">= 1.1.x"
+  },
+  "dependencies": {
+    "grunt": "0.3.x",
+    "grunt-contrib": "0.1.x",
+    "requirejs": "2.0.6",
+    "express": ">= 3.0.x",
+    "stylus": ">= 0.24.0",
+    "nib": ">= 0.3.2",
+    "jade": ">= 0.0.1",
+    "markdown": ">= 0.4.0",
+    "handlebars": "1.0.11",
+    "async": ">= 0.1.18",
+    "lodash": ">= 0.5.x",
+    "zipstream": ">=0.2.1",
+    "i18next": ">=1.5.0"
+  },
+  "scripts": {}
 }


### PR DESCRIPTION
Allow custom namespace and key separators (remove hard coding). Keys read, display, save and test correctly

Also fix package.json versioning issues: grunt, grunt-contrib and handlebars
All grunt tasks complete successfully
note: Node 0.8.x required to run 'grunt release' (zipstream module causes issues with >= 0.9.0)